### PR TITLE
small styling fix

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -84,7 +84,7 @@ To my knowledge this is the first public Fedimint instance. Any feedback is welc
 <!--
 {% if invoice %}
   <img style="height: 200pxm; width: 200px;" src="{{ qrcode(invoice) }}">
-  <div>{{ invoice }}</div>
+  <pre>{{ invoice }}</pre>
 {% endif %}
 
 <form method="post">
@@ -144,5 +144,10 @@ To my knowledge this is the first public Fedimint instance. Any feedback is welc
     max-width: 550px;
     text-align: justify;
     margin: auto;
+  }
+
+  pre {
+    word-wrap: break-word;
+    white-space: pre-wrap;
   }
 </style>


### PR DESCRIPTION
<img width="825" alt="Screen Shot 2022-10-13 at 10 38 06 AM" src="https://user-images.githubusercontent.com/543668/195627582-369717df-42b1-4fc4-8fd3-f5baae3127b8.png">

I also changed the invoice display to be a `pre` tag but it's commented out on master. would look like this:

<img width="674" alt="Screen Shot 2022-10-13 at 10 37 12 AM" src="https://user-images.githubusercontent.com/543668/195627596-df075301-7b6c-4ac0-b612-2997dc32d0c6.png">
