### PR TITLE
Make deployed fedimint version user configurable

### DIFF
--- a/faucet.py
+++ b/faucet.py
@@ -10,6 +10,8 @@ from lightning import LightningRpc
 
 rpc = LightningRpc(os.environ['RPC_SOCKET'])
 connect_str = os.environ['CONNECT_STRING']
+deployed_version = os.environ['DEPLOYED_VERSION']
+
 app = Flask(__name__)
 QRcode(app)
 
@@ -36,7 +38,7 @@ def index():
                 pay_result = str(e)
              
     return render_template('index.html', name='justin', 
-        invoice=invoice, pay_result=pay_result, connect_str=connect_str)
+        invoice=invoice, pay_result=pay_result, connect_str=connect_str, deployed_version=deployed_version)
 
 
 if __name__ == "__main__":

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
 
 <p>
   This signet <a href="https://github.com/fedimint/fedimint">Fedimint</a> instance runs on commit
-  <a href="https://github.com/fedimint/fedimint/commit/734f1414298816ef36ae5ca1299049556276ebd6"><code>734f141</code></a>.
+  <a href="https://github.com/fedimint/fedimint/tree/{{ deployed_version }}"><code>{{ deployed_version }}</code></a>.
   To test it there exist four clients:
   <ul>
     <li>


### PR DESCRIPTION
I don't want to patch the faucet every time we upgrade. This will help me deploy #17 which I'd otherwise have to rebase on 162417e6d5c6824ae80fa29dbc036c25841ea6f3.